### PR TITLE
Install Git in the image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,4 +12,6 @@ RUN set -x && \
     sha256sum -c /tmp/CHECKSUM && \
     tar -xzvf "/tmp/oc.tgz" && \
     cp "/tmp/${ARCHIVE}/oc" /bin/oc && \
-    rm -rf /tmp/*
+    rm -rf /tmp/* && \
+    yum install -y git && \
+    yum clean all -y

--- a/v3.6/Dockerfile
+++ b/v3.6/Dockerfile
@@ -12,4 +12,6 @@ RUN set -x && \
     sha256sum -c /tmp/CHECKSUM && \
     tar -xzvf "/tmp/oc.tgz" && \
     cp "/tmp/${ARCHIVE}/oc" /bin/oc && \
-    rm -rf /tmp/*
+    rm -rf /tmp/* && \
+    yum install -y git && \
+    yum clean all -y

--- a/v3.7/Dockerfile
+++ b/v3.7/Dockerfile
@@ -12,4 +12,6 @@ RUN set -x && \
     sha256sum -c /tmp/CHECKSUM && \
     tar -xzvf "/tmp/oc.tgz" && \
     cp "/tmp/${ARCHIVE}/oc" /bin/oc && \
-    rm -rf /tmp/*
+    rm -rf /tmp/* && \
+    yum install -y git && \
+    yum clean all -y

--- a/v3.9/Dockerfile
+++ b/v3.9/Dockerfile
@@ -12,4 +12,6 @@ RUN set -x && \
     sha256sum -c /tmp/CHECKSUM && \
     tar -xzvf "/tmp/oc.tgz" && \
     cp "/tmp/${ARCHIVE}/oc" /bin/oc && \
-    rm -rf /tmp/*
+    rm -rf /tmp/* && \
+    yum install -y git && \
+    yum clean all -y


### PR DESCRIPTION
This change installs Git in the image.

Git is helpful in relation to using the OpenShift client sometimes when you need to get information for the current commit or tag when the CI platform doesn't provide such infos (e.g. Bitbucket Pipelines, which provide the Git tag only in a `pipelines: tags: ...` section).