### PR TITLE
Revert "Set entrypoint, absolute base image reference"

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:7
+FROM centos:7
 
 ENV VERSION=%%VERSION%% \
     ARCHIVE=%%ARCHIVE%% \
@@ -19,7 +19,3 @@ RUN set -x && \
     yum install -y git && \
     yum clean all -y && \
     git clone --depth=1 ${OC_PLUGINS_REPO} ${KUBECTL_PLUGINS_PATH}
-
-WORKDIR /
-ENTRYPOINT ["/bin/oc"]
-CMD []

--- a/v3.10/Dockerfile
+++ b/v3.10/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:7
+FROM centos:7
 
 ENV VERSION=v3.10.0 \
     ARCHIVE=openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit \
@@ -19,7 +19,3 @@ RUN set -x && \
     yum install -y git && \
     yum clean all -y && \
     git clone --depth=1 ${OC_PLUGINS_REPO} ${KUBECTL_PLUGINS_PATH}
-
-WORKDIR /
-ENTRYPOINT ["/bin/oc"]
-CMD []

--- a/v3.11/Dockerfile
+++ b/v3.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:7
+FROM centos:7
 
 ENV VERSION=v3.11.0 \
     ARCHIVE=openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit \
@@ -19,7 +19,3 @@ RUN set -x && \
     yum install -y git && \
     yum clean all -y && \
     git clone --depth=1 ${OC_PLUGINS_REPO} ${KUBECTL_PLUGINS_PATH}
-
-WORKDIR /
-ENTRYPOINT ["/bin/oc"]
-CMD []

--- a/v3.6/Dockerfile
+++ b/v3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:7
+FROM centos:7
 
 ENV VERSION=v3.6.1 \
     ARCHIVE=openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit \
@@ -19,7 +19,3 @@ RUN set -x && \
     yum install -y git && \
     yum clean all -y && \
     git clone --depth=1 ${OC_PLUGINS_REPO} ${KUBECTL_PLUGINS_PATH}
-
-WORKDIR /
-ENTRYPOINT ["/bin/oc"]
-CMD []

--- a/v3.7/Dockerfile
+++ b/v3.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:7
+FROM centos:7
 
 ENV VERSION=v3.7.2 \
     ARCHIVE=openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit \
@@ -19,7 +19,3 @@ RUN set -x && \
     yum install -y git && \
     yum clean all -y && \
     git clone --depth=1 ${OC_PLUGINS_REPO} ${KUBECTL_PLUGINS_PATH}
-
-WORKDIR /
-ENTRYPOINT ["/bin/oc"]
-CMD []

--- a/v3.9/Dockerfile
+++ b/v3.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:7
+FROM centos:7
 
 ENV VERSION=v3.9.0 \
     ARCHIVE=openshift-origin-client-tools-v3.9.0-191fece-linux-64bit \
@@ -19,7 +19,3 @@ RUN set -x && \
     yum install -y git && \
     yum clean all -y && \
     git clone --depth=1 ${OC_PLUGINS_REPO} ${KUBECTL_PLUGINS_PATH}
-
-WORKDIR /
-ENTRYPOINT ["/bin/oc"]
-CMD []


### PR DESCRIPTION
The change to `ENTRYPOINT` broke all Gitlab CI pipelines (the main reason this container exists) - Gitlab CI passes `sh` commands to the container.

Reverts appuio/container-oc#12