### PR TITLE
Bump helm to v2.12.2

### DIFF
--- a/v3.10/Dockerfile
+++ b/v3.10/Dockerfile
@@ -1,10 +1,10 @@
 FROM docker.io/library/centos:7
 
 ENV VERSION=v3.10.0 \
-    HELM_VERSION=v2.12.1 \
+    HELM_VERSION=v2.12.2 \
     ARCHIVE=openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit \
     SHA256SUM=0f54235127884309d19b23e8e64e347f783efd6b5a94b49bfc4d0bf472efb5b8 \
-    HELM_SHA256SUM=891004bec55431b39515e2cedc4f4a06e93782aa03a4904f2bd742b168160451 \
+    HELM_SHA256SUM=edad6d5e594408b996b8d758a04948f89dab15fa6c6ea6daee3709f8c099df6d \
     OKD_REPO_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     OC_PLUGINS_REPO="https://github.com/appuio/oc-plugins" \

--- a/v3.11/Dockerfile
+++ b/v3.11/Dockerfile
@@ -1,10 +1,10 @@
 FROM docker.io/library/centos:7
 
 ENV VERSION=v3.11.0 \
-    HELM_VERSION=v2.12.1 \
+    HELM_VERSION=v2.12.2 \
     ARCHIVE=openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit \
     SHA256SUM=4b0f07428ba854174c58d2e38287e5402964c9a9355f6c359d1242efd0990da3 \
-    HELM_SHA256SUM=891004bec55431b39515e2cedc4f4a06e93782aa03a4904f2bd742b168160451 \
+    HELM_SHA256SUM=edad6d5e594408b996b8d758a04948f89dab15fa6c6ea6daee3709f8c099df6d \
     OKD_REPO_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     OC_PLUGINS_REPO="https://github.com/appuio/oc-plugins" \

--- a/v3.6/Dockerfile
+++ b/v3.6/Dockerfile
@@ -1,10 +1,10 @@
 FROM docker.io/library/centos:7
 
 ENV VERSION=v3.6.1 \
-    HELM_VERSION=v2.12.1 \
+    HELM_VERSION=v2.12.2 \
     ARCHIVE=openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit \
     SHA256SUM=922afb7a5642040ea7a6b780cd68eb1d15533b6376b503351a4c38a452338d11 \
-    HELM_SHA256SUM=891004bec55431b39515e2cedc4f4a06e93782aa03a4904f2bd742b168160451 \
+    HELM_SHA256SUM=edad6d5e594408b996b8d758a04948f89dab15fa6c6ea6daee3709f8c099df6d \
     OKD_REPO_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     OC_PLUGINS_REPO="https://github.com/appuio/oc-plugins" \

--- a/v3.7/Dockerfile
+++ b/v3.7/Dockerfile
@@ -1,10 +1,10 @@
 FROM docker.io/library/centos:7
 
 ENV VERSION=v3.7.2 \
-    HELM_VERSION=v2.12.1 \
+    HELM_VERSION=v2.12.2 \
     ARCHIVE=openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit \
     SHA256SUM=abc89f025524eb205e433622e59843b09d2304cc913534c4ed8af627da238624 \
-    HELM_SHA256SUM=891004bec55431b39515e2cedc4f4a06e93782aa03a4904f2bd742b168160451 \
+    HELM_SHA256SUM=edad6d5e594408b996b8d758a04948f89dab15fa6c6ea6daee3709f8c099df6d \
     OKD_REPO_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     OC_PLUGINS_REPO="https://github.com/appuio/oc-plugins" \

--- a/v3.9/Dockerfile
+++ b/v3.9/Dockerfile
@@ -1,10 +1,10 @@
 FROM docker.io/library/centos:7
 
 ENV VERSION=v3.9.0 \
-    HELM_VERSION=v2.12.1 \
+    HELM_VERSION=v2.12.2 \
     ARCHIVE=openshift-origin-client-tools-v3.9.0-191fece-linux-64bit \
     SHA256SUM=6ed2fb1579b14b4557e4450a807c97cd1b68a6c727cd1e12deedc5512907222e \
-    HELM_SHA256SUM=891004bec55431b39515e2cedc4f4a06e93782aa03a4904f2bd742b168160451 \
+    HELM_SHA256SUM=edad6d5e594408b996b8d758a04948f89dab15fa6c6ea6daee3709f8c099df6d \
     OKD_REPO_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     OC_PLUGINS_REPO="https://github.com/appuio/oc-plugins" \


### PR DESCRIPTION
To fix the security vulnerability [1].

[1] https://helm.sh/blog/helm-security-notice-2019/index.html