### PR TITLE
Upgrade Kustomize to v3.0.0-pre1

### DIFF
--- a/v3.10/Dockerfile
+++ b/v3.10/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.10.0 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v3.0.0-pre1 \
     ARCHIVE=openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit \
     SHA256SUM=0f54235127884309d19b23e8e64e347f783efd6b5a94b49bfc4d0bf472efb5b8 \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=088a0675b11ec4795a2de5932c119980a124447b1c025f8dd5cf59925a5b8e3b \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \

--- a/v3.11/Dockerfile
+++ b/v3.11/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.11.0 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v3.0.0-pre1 \
     ARCHIVE=openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit \
     SHA256SUM=4b0f07428ba854174c58d2e38287e5402964c9a9355f6c359d1242efd0990da3 \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=088a0675b11ec4795a2de5932c119980a124447b1c025f8dd5cf59925a5b8e3b \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \

--- a/v3.6/Dockerfile
+++ b/v3.6/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.6.1 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v3.0.0-pre1 \
     ARCHIVE=openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit \
     SHA256SUM=922afb7a5642040ea7a6b780cd68eb1d15533b6376b503351a4c38a452338d11 \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=088a0675b11ec4795a2de5932c119980a124447b1c025f8dd5cf59925a5b8e3b \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \

--- a/v3.7/Dockerfile
+++ b/v3.7/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.7.2 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v3.0.0-pre1 \
     ARCHIVE=openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit \
     SHA256SUM=abc89f025524eb205e433622e59843b09d2304cc913534c4ed8af627da238624 \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=088a0675b11ec4795a2de5932c119980a124447b1c025f8dd5cf59925a5b8e3b \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \

--- a/v3.9/Dockerfile
+++ b/v3.9/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.9.0 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v3.0.0-pre1 \
     ARCHIVE=openshift-origin-client-tools-v3.9.0-191fece-linux-64bit \
     SHA256SUM=6ed2fb1579b14b4557e4450a807c97cd1b68a6c727cd1e12deedc5512907222e \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=088a0675b11ec4795a2de5932c119980a124447b1c025f8dd5cf59925a5b8e3b \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \


### PR DESCRIPTION
I simply ran `make` to upgrade the project, and interestingly the latest, [just-released version](https://github.com/kubernetes-sigs/kustomize/releases) of Kustomize was pulled in.

I haven't yet found a clear overview of what has changed, feature-wise, in order to understand what may break (if anything) of our current implementations, but we may need to prepare for that case anyway.