### PR TITLE
Ensure pre-releases are skipped for Kustomize

### DIFF
--- a/src/release.sh
+++ b/src/release.sh
@@ -24,6 +24,7 @@ helm_version=$(curl -sS https://api.github.com/repos/helm/helm/releases \
 kustomize_version=$(curl -sS https://api.github.com/repos/kubernetes-sigs/kustomize/releases \
   | jq --raw-output \
       '.[]| select(.prerelease|not) | .tag_name' \
+  | sed '/-pre/d' \
   | head -n 1)
 
 helm_shasum=$(curl -sS https://storage.googleapis.com/kubernetes-helm/helm-${helm_version}-linux-amd64.tar.gz.sha256)

--- a/v3.10/Dockerfile
+++ b/v3.10/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.10.0 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v2.1.0 \
     ARCHIVE=openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit \
     SHA256SUM=0f54235127884309d19b23e8e64e347f783efd6b5a94b49bfc4d0bf472efb5b8 \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=f12b81585fc70970c16cf8c9f9032c17fdbada288b500740bc001806fdce2f80 \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \

--- a/v3.11/Dockerfile
+++ b/v3.11/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.11.0 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v2.1.0 \
     ARCHIVE=openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit \
     SHA256SUM=4b0f07428ba854174c58d2e38287e5402964c9a9355f6c359d1242efd0990da3 \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=f12b81585fc70970c16cf8c9f9032c17fdbada288b500740bc001806fdce2f80 \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \

--- a/v3.6/Dockerfile
+++ b/v3.6/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.6.1 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v2.1.0 \
     ARCHIVE=openshift-origin-client-tools-v3.6.1-008f2d5-linux-64bit \
     SHA256SUM=922afb7a5642040ea7a6b780cd68eb1d15533b6376b503351a4c38a452338d11 \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=f12b81585fc70970c16cf8c9f9032c17fdbada288b500740bc001806fdce2f80 \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \

--- a/v3.7/Dockerfile
+++ b/v3.7/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.7.2 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v2.1.0 \
     ARCHIVE=openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit \
     SHA256SUM=abc89f025524eb205e433622e59843b09d2304cc913534c4ed8af627da238624 \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=f12b81585fc70970c16cf8c9f9032c17fdbada288b500740bc001806fdce2f80 \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \

--- a/v3.9/Dockerfile
+++ b/v3.9/Dockerfile
@@ -2,11 +2,11 @@ FROM docker.io/library/centos:7@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973
 
 ENV VERSION=v3.9.0 \
     HELM_VERSION=v2.14.1 \
-    KUSTOMIZE_VERSION=v2.0.3 \
+    KUSTOMIZE_VERSION=v2.1.0 \
     ARCHIVE=openshift-origin-client-tools-v3.9.0-191fece-linux-64bit \
     SHA256SUM=6ed2fb1579b14b4557e4450a807c97cd1b68a6c727cd1e12deedc5512907222e \
     HELM_SHA256SUM=804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896 \
-    KUSTOMIZE_SHA256SUM=a04d79a013827c9ebb0abfe9d41cbcedf507a0310386c8d9a7efec7a36f9d7a3 \
+    KUSTOMIZE_SHA256SUM=f12b81585fc70970c16cf8c9f9032c17fdbada288b500740bc001806fdce2f80 \
     OKD_RELEASES_URL="https://github.com/openshift/origin/releases/download" \
     HELM_RELEASES_URL="https://storage.googleapis.com/kubernetes-helm" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \


### PR DESCRIPTION
* Fixes the release script such that it considers Kustomize releases named `*-pre*` as pre-releases and ignores them.
* Upgrades the embedded `kustomize` script to v2.1.0

Obsoletes #23.