### PR TITLE
Change sops URL to match new release naming

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -31,7 +31,7 @@ RUN set -x && \
     KUBEVAL_URL="${KUBEVAL_RELEASES_URL}/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz" && \
     KUSTOMIZE_URL="${KUSTOMIZE_RELEASES_URL}/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" && \
     SEISO_URL="${SEISO_RELEASES_URL}/${SEISO_VERSION}/seiso_linux_amd64" && \
-    SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux" && \
+    SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64" && \
     YQ_URL="${YQ_RELEASES_URL}/${YQ_VERSION}/yq_linux_amd64" && \
     microdnf install -y tar gzip git python3 diffutils && \
     cd /tmp && \


### PR DESCRIPTION
Since v.3.8.0 there is no longer a release with the naming scheme sops-v0.0.0.linux

The closest match is now sops-v0.0.0.linux.amd64

See
https://github.com/getsops/sops/releases