### PR TITLE
Fix empty `/usr/share/zoneinfo`

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -33,7 +33,9 @@ RUN set -x && \
     SEISO_URL="${SEISO_RELEASES_URL}/${SEISO_VERSION}/seiso_linux_amd64" && \
     SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64" && \
     YQ_URL="${YQ_RELEASES_URL}/${YQ_VERSION}/yq_linux_amd64" && \
-    microdnf install -y tar gzip git python3 diffutils tzdata && \
+    microdnf install -y tar gzip git python3 diffutils && \
+    microdnf update tzdata -y && \
+    microdnf reinstall -y tzdata && \
     cd /tmp && \
     curl -sSL "$URL" -o /tmp/oc.tgz && \
     curl -sSL "$HELM3_URL" -o /tmp/helm3.tgz && \

--- a/v4.12/Dockerfile
+++ b/v4.12/Dockerfile
@@ -1,19 +1,19 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1739420147
 
 ENV VERSION=latest-4.12 \
-    HELM3_VERSION=v3.16.2 \
+    HELM3_VERSION=v3.17.1 \
     KUBEVAL_VERSION=v0.16.1 \
-    KUSTOMIZE_VERSION=v5.5.0 \
+    KUSTOMIZE_VERSION=v5.6.0 \
     SEISO_VERSION=v1.0.0 \
-    SOPS_VERSION=v3.9.1 \
-    YQ_VERSION=v4.44.3 \
+    SOPS_VERSION=v3.9.4 \
+    YQ_VERSION=v4.45.1 \
     ARCHIVE=openshift-client-linux \
-    HELM3_SHA256SUM=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb \
+    HELM3_SHA256SUM=3b66f3cd28409f29832b1b35b43d9922959a32d795003149707fea84cbcd4469 \
     KUBEVAL_SHA256SUM=2d6f9bda1423b93787fa05d9e8dfce2fc1190fefbcd9d0936b9635f3f78ba790 \
-    KUSTOMIZE_SHA256SUM=6703a3a70a0c47cf0b37694030b54f1175a9dfeb17b3818b623ed58b9dbc2a77 \
+    KUSTOMIZE_SHA256SUM=54e4031ddc4e7fc59e408da29e7c646e8e57b8088c51b84b3df0864f47b5148f \
     SEISO_SHA256SUM=40484059c23993b4e8d6b0add3debebb31ed1155b49a5ebdae987698b3176202 \
     SHA256SUM= \
-    YQ_SHA256SUM=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7 \
+    YQ_SHA256SUM=654d2943ca1d3be2024089eb4f270f4070f491a0610481d128509b2834870049 \
     HELM_RELEASES_URL="https://get.helm.sh" \
     KUBEVAL_RELEASES_URL="https://github.com/instrumenta/kubeval/releases/download" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \
@@ -34,6 +34,8 @@ RUN set -x && \
     SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64" && \
     YQ_URL="${YQ_RELEASES_URL}/${YQ_VERSION}/yq_linux_amd64" && \
     microdnf install -y tar gzip git python3 diffutils tzdata && \
+    microdnf update tzdata -y && \
+    microdnf reinstall -y tzdata && \
     cd /tmp && \
     curl -sSL "$URL" -o /tmp/oc.tgz && \
     curl -sSL "$HELM3_URL" -o /tmp/helm3.tgz && \

--- a/v4.13/Dockerfile
+++ b/v4.13/Dockerfile
@@ -1,19 +1,19 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1739420147
 
 ENV VERSION=latest-4.13 \
-    HELM3_VERSION=v3.16.2 \
+    HELM3_VERSION=v3.17.1 \
     KUBEVAL_VERSION=v0.16.1 \
-    KUSTOMIZE_VERSION=v5.5.0 \
+    KUSTOMIZE_VERSION=v5.6.0 \
     SEISO_VERSION=v1.0.0 \
-    SOPS_VERSION=v3.9.1 \
-    YQ_VERSION=v4.44.3 \
+    SOPS_VERSION=v3.9.4 \
+    YQ_VERSION=v4.45.1 \
     ARCHIVE=openshift-client-linux \
-    HELM3_SHA256SUM=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb \
+    HELM3_SHA256SUM=3b66f3cd28409f29832b1b35b43d9922959a32d795003149707fea84cbcd4469 \
     KUBEVAL_SHA256SUM=2d6f9bda1423b93787fa05d9e8dfce2fc1190fefbcd9d0936b9635f3f78ba790 \
-    KUSTOMIZE_SHA256SUM=6703a3a70a0c47cf0b37694030b54f1175a9dfeb17b3818b623ed58b9dbc2a77 \
+    KUSTOMIZE_SHA256SUM=54e4031ddc4e7fc59e408da29e7c646e8e57b8088c51b84b3df0864f47b5148f \
     SEISO_SHA256SUM=40484059c23993b4e8d6b0add3debebb31ed1155b49a5ebdae987698b3176202 \
     SHA256SUM= \
-    YQ_SHA256SUM=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7 \
+    YQ_SHA256SUM=654d2943ca1d3be2024089eb4f270f4070f491a0610481d128509b2834870049 \
     HELM_RELEASES_URL="https://get.helm.sh" \
     KUBEVAL_RELEASES_URL="https://github.com/instrumenta/kubeval/releases/download" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \
@@ -34,6 +34,8 @@ RUN set -x && \
     SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64" && \
     YQ_URL="${YQ_RELEASES_URL}/${YQ_VERSION}/yq_linux_amd64" && \
     microdnf install -y tar gzip git python3 diffutils tzdata && \
+    microdnf update tzdata -y && \
+    microdnf reinstall -y tzdata && \
     cd /tmp && \
     curl -sSL "$URL" -o /tmp/oc.tgz && \
     curl -sSL "$HELM3_URL" -o /tmp/helm3.tgz && \

--- a/v4.14/Dockerfile
+++ b/v4.14/Dockerfile
@@ -1,19 +1,19 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1739420147
 
 ENV VERSION=latest-4.14 \
-    HELM3_VERSION=v3.16.2 \
+    HELM3_VERSION=v3.17.1 \
     KUBEVAL_VERSION=v0.16.1 \
-    KUSTOMIZE_VERSION=v5.5.0 \
+    KUSTOMIZE_VERSION=v5.6.0 \
     SEISO_VERSION=v1.0.0 \
-    SOPS_VERSION=v3.9.1 \
-    YQ_VERSION=v4.44.3 \
+    SOPS_VERSION=v3.9.4 \
+    YQ_VERSION=v4.45.1 \
     ARCHIVE=openshift-client-linux \
-    HELM3_SHA256SUM=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb \
+    HELM3_SHA256SUM=3b66f3cd28409f29832b1b35b43d9922959a32d795003149707fea84cbcd4469 \
     KUBEVAL_SHA256SUM=2d6f9bda1423b93787fa05d9e8dfce2fc1190fefbcd9d0936b9635f3f78ba790 \
-    KUSTOMIZE_SHA256SUM=6703a3a70a0c47cf0b37694030b54f1175a9dfeb17b3818b623ed58b9dbc2a77 \
+    KUSTOMIZE_SHA256SUM=54e4031ddc4e7fc59e408da29e7c646e8e57b8088c51b84b3df0864f47b5148f \
     SEISO_SHA256SUM=40484059c23993b4e8d6b0add3debebb31ed1155b49a5ebdae987698b3176202 \
     SHA256SUM= \
-    YQ_SHA256SUM=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7 \
+    YQ_SHA256SUM=654d2943ca1d3be2024089eb4f270f4070f491a0610481d128509b2834870049 \
     HELM_RELEASES_URL="https://get.helm.sh" \
     KUBEVAL_RELEASES_URL="https://github.com/instrumenta/kubeval/releases/download" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \
@@ -34,6 +34,8 @@ RUN set -x && \
     SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64" && \
     YQ_URL="${YQ_RELEASES_URL}/${YQ_VERSION}/yq_linux_amd64" && \
     microdnf install -y tar gzip git python3 diffutils tzdata && \
+    microdnf update tzdata -y && \
+    microdnf reinstall -y tzdata && \
     cd /tmp && \
     curl -sSL "$URL" -o /tmp/oc.tgz && \
     curl -sSL "$HELM3_URL" -o /tmp/helm3.tgz && \

--- a/v4.15/Dockerfile
+++ b/v4.15/Dockerfile
@@ -1,19 +1,19 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1739420147
 
 ENV VERSION=latest-4.15 \
-    HELM3_VERSION=v3.16.2 \
+    HELM3_VERSION=v3.17.1 \
     KUBEVAL_VERSION=v0.16.1 \
-    KUSTOMIZE_VERSION=v5.5.0 \
+    KUSTOMIZE_VERSION=v5.6.0 \
     SEISO_VERSION=v1.0.0 \
-    SOPS_VERSION=v3.9.1 \
-    YQ_VERSION=v4.44.3 \
+    SOPS_VERSION=v3.9.4 \
+    YQ_VERSION=v4.45.1 \
     ARCHIVE=openshift-client-linux \
-    HELM3_SHA256SUM=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb \
+    HELM3_SHA256SUM=3b66f3cd28409f29832b1b35b43d9922959a32d795003149707fea84cbcd4469 \
     KUBEVAL_SHA256SUM=2d6f9bda1423b93787fa05d9e8dfce2fc1190fefbcd9d0936b9635f3f78ba790 \
-    KUSTOMIZE_SHA256SUM=6703a3a70a0c47cf0b37694030b54f1175a9dfeb17b3818b623ed58b9dbc2a77 \
+    KUSTOMIZE_SHA256SUM=54e4031ddc4e7fc59e408da29e7c646e8e57b8088c51b84b3df0864f47b5148f \
     SEISO_SHA256SUM=40484059c23993b4e8d6b0add3debebb31ed1155b49a5ebdae987698b3176202 \
     SHA256SUM= \
-    YQ_SHA256SUM=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7 \
+    YQ_SHA256SUM=654d2943ca1d3be2024089eb4f270f4070f491a0610481d128509b2834870049 \
     HELM_RELEASES_URL="https://get.helm.sh" \
     KUBEVAL_RELEASES_URL="https://github.com/instrumenta/kubeval/releases/download" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \
@@ -34,6 +34,8 @@ RUN set -x && \
     SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64" && \
     YQ_URL="${YQ_RELEASES_URL}/${YQ_VERSION}/yq_linux_amd64" && \
     microdnf install -y tar gzip git python3 diffutils tzdata && \
+    microdnf update tzdata -y && \
+    microdnf reinstall -y tzdata && \
     cd /tmp && \
     curl -sSL "$URL" -o /tmp/oc.tgz && \
     curl -sSL "$HELM3_URL" -o /tmp/helm3.tgz && \

--- a/v4.16/Dockerfile
+++ b/v4.16/Dockerfile
@@ -1,19 +1,19 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1739420147
 
 ENV VERSION=latest-4.16 \
-    HELM3_VERSION=v3.16.2 \
+    HELM3_VERSION=v3.17.1 \
     KUBEVAL_VERSION=v0.16.1 \
-    KUSTOMIZE_VERSION=v5.5.0 \
+    KUSTOMIZE_VERSION=v5.6.0 \
     SEISO_VERSION=v1.0.0 \
-    SOPS_VERSION=v3.9.1 \
-    YQ_VERSION=v4.44.3 \
+    SOPS_VERSION=v3.9.4 \
+    YQ_VERSION=v4.45.1 \
     ARCHIVE=openshift-client-linux \
-    HELM3_SHA256SUM=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb \
+    HELM3_SHA256SUM=3b66f3cd28409f29832b1b35b43d9922959a32d795003149707fea84cbcd4469 \
     KUBEVAL_SHA256SUM=2d6f9bda1423b93787fa05d9e8dfce2fc1190fefbcd9d0936b9635f3f78ba790 \
-    KUSTOMIZE_SHA256SUM=6703a3a70a0c47cf0b37694030b54f1175a9dfeb17b3818b623ed58b9dbc2a77 \
+    KUSTOMIZE_SHA256SUM=54e4031ddc4e7fc59e408da29e7c646e8e57b8088c51b84b3df0864f47b5148f \
     SEISO_SHA256SUM=40484059c23993b4e8d6b0add3debebb31ed1155b49a5ebdae987698b3176202 \
     SHA256SUM= \
-    YQ_SHA256SUM=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7 \
+    YQ_SHA256SUM=654d2943ca1d3be2024089eb4f270f4070f491a0610481d128509b2834870049 \
     HELM_RELEASES_URL="https://get.helm.sh" \
     KUBEVAL_RELEASES_URL="https://github.com/instrumenta/kubeval/releases/download" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \
@@ -34,6 +34,8 @@ RUN set -x && \
     SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64" && \
     YQ_URL="${YQ_RELEASES_URL}/${YQ_VERSION}/yq_linux_amd64" && \
     microdnf install -y tar gzip git python3 diffutils tzdata && \
+    microdnf update tzdata -y && \
+    microdnf reinstall -y tzdata && \
     cd /tmp && \
     curl -sSL "$URL" -o /tmp/oc.tgz && \
     curl -sSL "$HELM3_URL" -o /tmp/helm3.tgz && \

--- a/v4.17/Dockerfile
+++ b/v4.17/Dockerfile
@@ -1,19 +1,19 @@
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1739420147
 
 ENV VERSION=latest-4.17 \
-    HELM3_VERSION=v3.16.2 \
+    HELM3_VERSION=v3.17.1 \
     KUBEVAL_VERSION=v0.16.1 \
-    KUSTOMIZE_VERSION=v5.5.0 \
+    KUSTOMIZE_VERSION=v5.6.0 \
     SEISO_VERSION=v1.0.0 \
-    SOPS_VERSION=v3.9.1 \
-    YQ_VERSION=v4.44.3 \
+    SOPS_VERSION=v3.9.4 \
+    YQ_VERSION=v4.45.1 \
     ARCHIVE=openshift-client-linux \
-    HELM3_SHA256SUM=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb \
+    HELM3_SHA256SUM=3b66f3cd28409f29832b1b35b43d9922959a32d795003149707fea84cbcd4469 \
     KUBEVAL_SHA256SUM=2d6f9bda1423b93787fa05d9e8dfce2fc1190fefbcd9d0936b9635f3f78ba790 \
-    KUSTOMIZE_SHA256SUM=6703a3a70a0c47cf0b37694030b54f1175a9dfeb17b3818b623ed58b9dbc2a77 \
+    KUSTOMIZE_SHA256SUM=54e4031ddc4e7fc59e408da29e7c646e8e57b8088c51b84b3df0864f47b5148f \
     SEISO_SHA256SUM=40484059c23993b4e8d6b0add3debebb31ed1155b49a5ebdae987698b3176202 \
     SHA256SUM= \
-    YQ_SHA256SUM=a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7 \
+    YQ_SHA256SUM=654d2943ca1d3be2024089eb4f270f4070f491a0610481d128509b2834870049 \
     HELM_RELEASES_URL="https://get.helm.sh" \
     KUBEVAL_RELEASES_URL="https://github.com/instrumenta/kubeval/releases/download" \
     KUSTOMIZE_RELEASES_URL="https://github.com/kubernetes-sigs/kustomize/releases/download" \
@@ -34,6 +34,8 @@ RUN set -x && \
     SOPS_URL="${SOPS_RELEASES_URL}/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64" && \
     YQ_URL="${YQ_RELEASES_URL}/${YQ_VERSION}/yq_linux_amd64" && \
     microdnf install -y tar gzip git python3 diffutils tzdata && \
+    microdnf update tzdata -y && \
+    microdnf reinstall -y tzdata && \
     cd /tmp && \
     curl -sSL "$URL" -o /tmp/oc.tgz && \
     curl -sSL "$HELM3_URL" -o /tmp/helm3.tgz && \


### PR DESCRIPTION
RedHat BUM images contain a zeroed out `/usr/share/zoneinfo` to keep the images (too) lightweight.

The tzdata package is not fully removed because of dependency issues. Because of this an `install` is not enough to trigger the generation of a valid zoneinfo file.

This PR adds and update and reinstall step for tzdata as per https://access.redhat.com/solutions/5616681.