### PR TITLE
Update Renovate config to recommended standard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":disableDependencyDashboard"
   ],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":disableDependencyDashboard"
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Auto-merge GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["major", "minor", "patch", "digest"]
+    },
+    {
+      "description": "Auto-merge all minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Migrate from deprecated `config:base` to `config:recommended`
- Add `$schema` for editor validation and autocompletion
- Add auto-merge rules for GitHub Actions updates (major, minor, patch, digest)
- Add auto-merge rules for all minor and patch dependency updates

## Why
The current config uses the deprecated `config:base` preset and has no auto-merge rules, causing Renovate PRs to pile up (currently 4 open). With auto-merge enabled, routine updates (GH Actions, minor/patch bumps) will merge automatically after CI passes, reducing maintenance burden.

## Reference
Matches the standard config from [vshn/landingpager](https://github.com/vshn/landingpager/blob/main/renovate.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)