### PR TITLE
Prevent cleanup of old image SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,4 @@ jobs:
           tags: |
             docker.io/appuio/oc:v${{ matrix.oc }}
             quay.io/appuio/oc:v${{ matrix.oc }}
+            quay.io/appuio/oc:v${{ matrix.oc }}-${{ github.run_number }}.${{ github.run_attempt }}


### PR DESCRIPTION
Quay auto-cleans unreferenced SHAs, but we pin them for some repos. Adding a tag for each push so they keep being referenced.